### PR TITLE
Add a bug minimum sizing and wrapping on Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,36 @@ Padding and margins, when set in percentages, are always relative to the parent 
 
 This bug only affects flex items, so the solution is to apply any vertical padding or margins to an inner wrapper element. Demo [11.1.b](http://codepen.io/philipwalton/pen/vOORJa) shows an example of this.
 
+### 12. Minimum content sizing and wrapping
+
+<table>
+  <tr>
+    <th align="left">Demos</th>
+    <th align="left">Browsers affected</th>
+    <th align="left">Tracking bugs</th>
+  </tr>
+  <tr valign="top">
+    <td>
+      <a href="http://codepen.io/tzi/pen/rVmbvK">12.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/tzi/pen/doWEyo">12.1.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/tzi/pen/NqjZKe">12.2.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/tzi/pen/pJPXzX">12.2.b</a> &mdash; <em>workaround</em>
+    </td>
+    <td>
+      Safari<br>
+    </td>
+    <td>
+      <a href="https://bugs.webkit.org/show_bug.cgi?id=136041">Webkit #136041</a><br>
+    </td>
+  </tr>
+</table>
+
+When several flex items are too big to fit inside in a single line in their container, those items should wrap according to the container `flex-wrap` property. If you set a minimum size using a `min-width`, it will never wrap and overflow instead. If you set a minimum size using a `flex-basis` and `flex-shrink: 0`, it never wrap and will shrink instead.
+
+#### Workaround
+
+Adding a `display: inline-block` on flex items fix this. Demo [12.1.b](http://codepen.io/philipwalton/pen/doWEyo) shows an example with `min-width`. Demo [12.2.b](http://codepen.io/philipwalton/pen/pJPXzX) shows an example with `flex-basis`.
+
 ## Acknowledgements
 
 Flexbugs was created as a follow-up to the article [Normalizing Cross-Browser Flexbox Bugs](http://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/). It's maintained by [@philwalton](https://twitter.com/philwalton) and [@gregwhitworth](https://twitter.com/gregwhitworth). If you have any questions or would like to get involved, please feel free to reach out to either of us on Twitter.

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ This bug only affects flex items, so the solution is to apply any vertical paddi
   </tr>
 </table>
 
-When several flex items are too big to fit inside in a single line in their container, those items should wrap according to the container `flex-wrap` property. If you set a minimum size using a `min-width`, it will never wrap and overflow instead. If you set a minimum size using a `flex-basis` and `flex-shrink: 0`, it never wrap and will shrink instead.
+When several flex items are too big to fit inside in a single line in their container, those items should wrap according to the container `flex-wrap` property. On Safari, if you set a minimum size using a `min-width`, it will never wrap and overflow instead. If you set a minimum size using a `flex-basis` and `flex-shrink: 0`, it will never wrap and shrink instead.
 
 #### Workaround
 

--- a/README.md
+++ b/README.md
@@ -340,9 +340,9 @@ This bug only affects flex items, so the solution is to apply any vertical paddi
   <tr valign="top">
     <td>
       <a href="http://codepen.io/tzi/pen/rVmbvK">12.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/tzi/pen/doWEyo">12.1.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/tzi/pen/doWEyo">12.1.b</a> &mdash; <em>workaround</em><br>
       <a href="http://codepen.io/tzi/pen/NqjZKe">12.2.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/tzi/pen/pJPXzX">12.2.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/tzi/pen/pJPXzX">12.2.b</a> &mdash; <em>workaround</em><br>
     </td>
     <td>
       Safari<br>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 9. [`<button>` elements can't be flex containers](#9-button-elements-cant-be-flex-containers)
 10. [`align-items: baseline` doesn't work with nested flex containers](#10-align-items-baseline-doesnt-work-with-nested-flex-containers)
 11. [Vertical, percentage-based padding and margins don't work on flex items](#11-vertical-percentage-based-padding-and-margins-dont-work-on-flex-items)
+12. [Minimum content sizing and wrapping](#12-minimum-content-sizing-and-wrapping)
 
 ### 1. Minimum content sizing of flex items not honored
 


### PR DESCRIPTION
Hi!

Thanks for this curated list!
It's awesome :+1: 

I propose to add a annoying bug about `flex-wrap` on Safari (6, 7 & 8).

Cheers,
Thomas.