### PR TITLE
Flexbox bug in IE11: Justify-content: space-around 

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ There are two ways to work around this bug. The first requires no additional mar
 
 IE 10-11 ignore `calc()` functions used in `flex` shorthand declarations. Demo [8.1.a](http://codepen.io/philipwalton/pen/ogBrye) shows `flex:0 0 calc(100%/3)` not working in IE.
 
-In IE 10, `calc()` functions to not even work in non-shorthand `flex-basis` declarations (though this does work in IE 11). Demo [8.2.a](http://codepen.io/philipwalton/pen/VYJgJo) shows `flex-basis: calc(100%/3)` not working in IE 10.
+In IE 10, `calc()` functions don't even work in longhand `flex-basis` declarations (though this does work in IE 11+). Demo [8.2.a](http://codepen.io/philipwalton/pen/VYJgJo) shows `flex-basis: calc(100%/3)` not working in IE 10.
 
 #### Workaround
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 4. [`flex` shorthand declarations with unitless `flex-basis` values are ignored](#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored)
 5. [Column flex items don't always preserve intrinsic aspect ratios](#5-column-flex-items-dont-always-preserve-intrinsic-aspect-ratios)
 6. [The default `flex` value has changed](#6-the-default-flex-value-has-changed)
-7. [`flex-basis` doesn't account for `box-sizing:border-box`](#user-content-7-flex-basis-doesnt-account-for-box-sizingborder-box)
+7. [`flex-basis` doesn't account for `box-sizing:border-box`](#7-flex-basis-doesnt-account-for-box-sizingborder-box)
 
 ### 1. Minimum content sizing of flex items not honored
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 5. [Column flex items don't always preserve intrinsic aspect ratios](#5-column-flex-items-dont-always-preserve-intrinsic-aspect-ratios)
 6. [The default `flex` value has changed](#6-the-default-flex-value-has-changed)
 7. [`flex-basis` doesn't account for `box-sizing:border-box`](#7-flex-basis-doesnt-account-for-box-sizingborder-box)
-8. [`flex` shorthand doesn't support `calc()`](#8-flex-shorthand-doesnt-support-calc)
+8. [`flex-basis` doesn't support `calc()`](#8-flex-basis-doesnt-support-calc)
 9. [`<button>` elements can't be flex containers](#9-button-elements-cant-be-flex-containers)
 
 
@@ -205,7 +205,7 @@ If you have to support IE 10, the best solution is to *always* set an explicit `
 
 An explicit `flex-basis` value (i.e., any value other than `auto`) is supposed to act just like `width` or `height`. It determines the initial size of a flex item and then the other flexibility properties allow it to grow or shrink accordingly.
 
-Internet Explorer 10-11 always assume a content box model when using `flex-basis` to determine a flex item's size, even if that item is set to `box-sizing:border-box`. Demo [7.1.a](http://codepen.io/philipwalton/pen/JoWjyb) shows that an item with a `flex-basis` value of `100%` will overflow its container by the amount of its border plus its padding.
+IE 10-11 always assume a content box model when using `flex-basis` to determine a flex item's size, even if that item is set to `box-sizing:border-box`. Demo [7.1.a](http://codepen.io/philipwalton/pen/JoWjyb) shows that an item with a `flex-basis` value of `100%` will overflow its container by the amount of its border plus its padding.
 
 #### Workaround
 
@@ -214,7 +214,7 @@ There are two ways to work around this bug. The first requires no additional mar
 1. Instead of setting an explicit `flex-basis` value, use `auto`, and then set an explicit width or height. Demo [7.1.b](http://codepen.io/philipwalton/pen/XJMWem) shows this.
 2. Use a wrapper element that contains no border or padding so it works with the content box model. Demo [7.1.c](http://codepen.io/philipwalton/pen/ZYLdqb) show this.
 
-### 8. `flex` shorthand doesn't support `calc()`
+### 8. `flex-basis` doesn't support `calc()`
 
 <table>
   <tr>
@@ -228,13 +228,24 @@ There are two ways to work around this bug. The first requires no additional mar
     </td>
     <td>Internet Explorer 10-11 (fixed in 12+)</td>
   </tr>
+  <tr valign="top">
+    <td>
+      <a href="http://codepen.io/philipwalton/pen/VYJgJo">8.2.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/pvXGmW">8.2.b</a> &mdash; <em>workaround</em>
+    </td>
+    <td>Internet Explorer 10 (fixed in 11+)</td>
+  </tr>
 </table>
 
-Internet Explorer 10-11 ignore `flex` shorthand declarations that use the `calc()` function in their `flex-basis` portion. Demo [8.1.a](http://codepen.io/philipwalton/pen/ogBrye) show how `flex:0 0 calc(100%/3)` breaks in IE.
+IE 10-11 ignore `calc()` functions used in `flex` shorthand declarations. Demo [8.1.a](http://codepen.io/philipwalton/pen/ogBrye) shows `flex:0 0 calc(100%/3)` not working in IE.
+
+In IE 10, `calc()` functions to not even work in non-shorthand `flex-basis` declarations (though this does work in IE 11). Demo [8.2.a](http://codepen.io/philipwalton/pen/VYJgJo) shows `flex-basis: calc(100%/3)` not working in IE 10.
 
 #### Workaround
 
-This bug only affects the `flex` shorthand, so if you need to use `calc()` make sure to specify each flexibility property individually. Demo [8.1.b](http://codepen.io/philipwalton/pen/bNgPKz) offers an example of this.
+Since this bug only affects the `flex` shorthand declaration in IE 11, an easy workaround (if you only need to support IE 11+) is to always specify each flexibility property individually. Demo [8.1.b](http://codepen.io/philipwalton/pen/bNgPKz) offers an example of this.
+
+If you need to support IE 10 as well, then you'll need to fall back to setting `width` or `height` (depending on the container's `flex-direction` property). You can do this by setting a `flex-basis` value of `auto`, which will instruct the browser to use the element's [main size](http://dev.w3.org/csswg/css-flexbox/#box-model) property (i.e., its `width` or `height`). Demo [8.2.b](http://codepen.io/philipwalton/pen/pvXGmW) offers an example of this.
 
 ### 9. `<button>` elements can't be flex containers
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 
 1. [Minimum content sizing of flex items not honored](#1-minimum-content-sizing-of-flex-items-not-honored)
 2. [Column flex items set to `align-items:center` overflow their container](#2-column-flex-items-set-to-align-itemscenter-overflow-their-container)
-3. [`min-height` on a flex container won't apply to its flex items](#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items)
+3. [`min-height` on a column flex container won't apply to its flex items](#3-min-height-on-a-column-flex-container-wont-apply-to-its-flex-items)
 4. [`flex` shorthand declarations with unitless `flex-basis` values are ignored](#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored)
 5. [Column flex items don't always preserve intrinsic aspect ratios](#5-column-flex-items-dont-always-preserve-intrinsic-aspect-ratios)
 
@@ -70,7 +70,7 @@ When using `align-items:center` on a flex container in the column direction, the
 
 Most of the time, this can be fixed by simply setting `max-width:100%` on the flex item. If the flex item has a padding or border set, you'll also need to make sure to use `box-sizing:border-box` to account for that space. If the flex item has a margin, using `box-sizing` alone will not work, so you may need to use a container element with padding instead.
 
-### 3. `min-height` on a flex container won't apply to its flex items
+### 3. `min-height` on a column flex container won't apply to its flex items
 
 <table>
   <tr>

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This repo aims to be community curated list of cross-browser flexbox issues and 
 
 As the spec continues to evolve and vendors nail down their implementations, this repo will be updated with newly discovered issues and remove old issues as their fixed or become obsolete.
 
-## Table of contents
+## The bugs and their workarounds
 
 1. [Minimum content sizing of flex items not honored](#1-minimum-content-sizing-of-flex-items-not-honored)
-2. [Column direction flex items set to `align-items:center` overflow their container](#2-column-direction-flex-items-set-to-align-itemscenter-overflow-their-container)
+2. [Column flex items set to `align-items:center` overflow their container](#2-column-flex-items-set-to-align-itemscenter-overflow-their-container)
 3. [`min-height` on a flex container won't apply to its flex items](#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items)
 4. [`flex` shorthand declarations with unitless `flex-basis` values are ignored](#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored)
-5. [Flex items in the column direction don't always preserve intrinsic aspect ratios](#5-flex-items-in-the-column-direction-dont-always-preserve-intrinsic-aspect-ratios)
+5. [Column flex items don't always preserve intrinsic aspect ratios](#5-column-flex-items-dont-always-preserve-intrinsic-aspect-ratios)
 
 ### 1. Minimum content sizing of flex items not honored
 
@@ -36,9 +36,9 @@ As the spec continues to evolve and vendors nail down their implementations, thi
   </tr>
 </table>
 
-When flex items are too big to fit inside their container, those items are instructed (by the flex layout algorithm) to shrink, proportionally, according to their `flex-shink` property. But contrary to what most browsers allow, they're *not* supposed to shrink indefinitely. They must always be at least as big as their minimum height or width properties declare, and if no minimum height or width properties are set, their minimum size should be the default minimum size of their content.
+When flex items are too big to fit inside their container, those items are instructed (by the flex layout algorithm) to shrink, proportionally, according to their `flex-shrink` property. But contrary to what most browsers allow, they're *not* supposed to shrink indefinitely. They must always be at least as big as their minimum height or width properties declare, and if no minimum height or width properties are set, their minimum size should be the default minimum size of their content.
 
-According to the [flexbox specification](http://www.w3.org/TR/css-flexbox/#flex-common):
+According to the [current flexbox specification](http://www.w3.org/TR/css-flexbox/#flex-common):
 
 > By default, flex items won’t shrink below their minimum content size (the length of the longest word or fixed-size element). To change this, set the min-width or min-height property.
 
@@ -46,7 +46,7 @@ According to the [flexbox specification](http://www.w3.org/TR/css-flexbox/#flex-
 
 The flexbox spec defines an initial `flex-shrink` value of `1` but says items should not shrink below their default minimum content size. You can get pretty much this exact same behavior by using a `flex-shrink` value of `0` instead of the default `1`. If your element is already being sized based on its children, and it hasn't set a `width`, `height`, or `flex-basis` value, then setting `flex-shrink:0` will render it the same way&mdash;but it will avoid this bug.
 
-### 2. Column direction flex items set to `align-items:center` overflow their container
+### 2. Column flex items set to `align-items:center` overflow their container
 
 <table>
   <tr>
@@ -64,11 +64,11 @@ The flexbox spec defines an initial `flex-shrink` value of `1` but says items sh
   </tr>
 </table>
 
-When using `align-items:center` on a flex container in the column direction, the contents of flex item, if too big on one line, will overflow their container in IE 10-11.
+When using `align-items:center` on a flex container in the column direction, the contents of flex item, if too big, will overflow their container in IE 10-11.
 
 #### Workaround
 
-Most of the time, this can be fixed by simply setting `max-width:100%` on the flex item. If the flex item has a padding or border set, you'll also need to make sure to use `box-sizing:border-box` to account for that space. If the flex item has a margin, using `box-sizing` alone will not work, so you may need to use a container element with a padding instead.
+Most of the time, this can be fixed by simply setting `max-width:100%` on the flex item. If the flex item has a padding or border set, you'll also need to make sure to use `box-sizing:border-box` to account for that space. If the flex item has a margin, using `box-sizing` alone will not work, so you may need to use a container element with padding instead.
 
 ### 3. `min-height` on a flex container won't apply to its flex items
 
@@ -91,13 +91,13 @@ Most of the time, this can be fixed by simply setting `max-width:100%` on the fl
 
 In order for flex items to size and position themselves, they need to know how big their containers are. For example, if a flex item is supposed to be vertically centered, it needs to know how tall its parent is. The same is true when flex items are told to grow to fill the remaining empty space.
 
-In IE 10-11, `min-height` declarations on flex containers in the column direction work to size the containers themselves, but their flex item children do not seem to know this information. They act as if no height has been set.
+In IE 10-11, `min-height` declarations on flex containers in the column direction work to size the containers themselves, but their flex item children do not seem to know the size of their parents. They act as if no height has been set at all.
 
 #### Workaround
 
-By far the most common element to apply `min-height` to is the body element, and usually you're setting it to `100%` (or `100vh`). Since the body element will never have contents below it, and since having a vertical scroll bar appear when there's a lot of content on the page is usually the desired behavior, substituting `height` for `min-height` will almost always work. Demo [3.1.b](http://codepen.io/philipwalton/full/KwNvLo) shows the solution to [3.1.a](http://codepen.io/philipwalton/full/RNoZJP).
+By far the most common element to apply `min-height` to is the body element, and usually you're setting it to `100%` (or `100vh`). Since the body element will never have any content below it, and since having a vertical scroll bar appear when there's a lot of content on the page is usually the desired behavior, substituting `height` for `min-height` will almost always work as shown in demo [3.1.b](http://codepen.io/philipwalton/full/KwNvLo).
 
-There are cases, however, where no good workaround exists. Demo [3.2.a] shows a visual design where `min-height` is truly needed and a `height` substitution will not work. In such cases, you may need to rethink your design or resort to a [browser detection hack](http://stackoverflow.com/questions/20541306/how-to-write-a-css-hack-for-ie-11).
+There are cases, however, where no good workaround exists. Demo [3.2.a](http://codepen.io/philipwalton/full/VYmbmj) shows a visual design where `min-height` is truly needed and a `height` substitution will not work. In such cases, you may need to rethink your design or resort to a [browser detection hack](http://stackoverflow.com/questions/20541306/how-to-write-a-css-hack-for-ie-11).
 
 ### 4. `flex` shorthand declarations with unitless `flex-basis` values are ignored
 
@@ -123,11 +123,11 @@ This is no longer true in the spec, but IE 10-11 still treat it as true. If you 
 
 #### Workaround
 
-When using the `flex` shorthand, always include a unit in the flex-basis portion. For example: `1 0 0%`.
+When using the `flex` shorthand, always include a unit in the `flex-basis` portion. For example: `1 0 0%`.
 
 **Important:** using a `flex` value of something like `1 0 0px` can still be a problem because many CSS minifiers will convert `0px` to `0`. To avoid this, make sure to use `0%` instead of `0px` since most minifiers won't touch percentage values for other reasons.
 
-### 5. Flex items in the column direction don't always preserve intrinsic aspect ratios
+### 5. Column flex items don't always preserve intrinsic aspect ratios
 
 <table>
   <tr>
@@ -147,13 +147,13 @@ The [March 2014 spec](http://www.w3.org/TR/2014/WD-css-flexbox-1-20140325/#min-s
 
 > On a flex item whose overflow is not visible, this [auto] keyword specifies as the minimum size the smaller of: (a) the min-content size, or (b) the computed width/height, if that value is definite.
 
-Demo [5.1.a](http://codepen.io/philipwalton/full/LEbQON) contains an image whose height is 200 pixel and whose width is 500 pixel. Its container, however, is only 300 pixels wide, so after the image is scaled to fit into that space, its computed height should only be 120 pixels. The text quoted above does not make it clear as to whether the flex item's min-content size should be based the image's actual height or scaled height.
+Demo [5.1.a](http://codepen.io/philipwalton/full/LEbQON) contains an image whose height is 200 pixels and whose width is 500 pixels. Its container, however, is only 300 pixels wide, so after the image is scaled to fit into that space, its computed height should only be 120 pixels. The text quoted above does not make it clear as to whether the flex item's min-content size should be based the image's actual height or scaled height.
 
 The [most recent spec](http://dev.w3.org/csswg/css-flexbox/#min-size-auto) has resolved this ambiguity in favor of using sizes that will preserve an element's intrinsic aspect ratio.
 
 #### Workaround
 
-This problem can easily be avoided by adding a container element to house the element with the intrinsic aspect ratio. Since doing this causes the element with the intrinsic aspect ratio to no longer be a flex item, it will be sized as normal.
+You can avoid this problem by adding a container element to house the element with the intrinsic aspect ratio. Since doing this causes the element with the intrinsic aspect ratio to no longer be a flex item, it will be sized normally.
 
 ## Acknowledgements
 
@@ -161,4 +161,4 @@ Flexbugs was created as a follow-up to the article [Normalizing Cross-Browser Fl
 
 ## Contributing
 
-If you've discovered a flexbox bug or would like to submit a workaround, please open an issue or submit a pull request. Make sure to submit relevant test cases and screenshots and indicate which browsers are affected by the issue.
+If you've discovered a flexbox bug or would like to submit a workaround, please open an issue or submit a pull request. Make sure to submit relevant test cases or screenshots and indicate which browsers are affected.

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ This bug only affects flex items, so the solution is to apply any vertical paddi
 
 Safari uses min/max width/height declarations for actually rendering the size of flex items, but it ignores those values when calculating how many items should be on a single line of a multi-line flex container. Instead, it simply uses the item's `flex-basis` value, or its width if the flex basis is set to `auto`.
 
-This is problematic when using the `flex: 1` shorthand because that sets the flex basis to `0%`, and an infinite number of flex items could fit on a single line if the browser thinks their widths are all zero.
+This is problematic when using the `flex: 1` shorthand because that sets the flex basis to `0%`, and an infinite number of flex items could fit on a single line if the browser thinks their widths are all zero. Demo [12.1.a](http://codepen.io/philipwalton/pen/BNrGwN) show an example of this happening.
 
 This is also problematic when creating fluid layouts where you want your flex items to be no bigger than X but no smaller than Y. Since Safari ignores those values when determining how many items fit on a line, that strategy won't work.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Most of the time, this can be fixed by simply setting `max-width:100%` on the fl
       <a href="http://codepen.io/philipwalton/full/KwNvLo">3.1.b</a> &mdash; <em>workaround</em><br>
       <a href="http://codepen.io/philipwalton/full/VYmbmj">3.2.a</a> &mdash; <em>bug</em><br>
     </td>
-    <td>Internet Explorer 10-11</td>
+    <td>Internet Explorer (10-11)</td>
     <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">connect.microsoft.com</a></td>
   </tr>
 </table>
@@ -111,7 +111,7 @@ There are cases, however, where no good workaround exists. Demo [3.2.a](http://c
       <a href="http://codepen.io/philipwalton/full/OPbQgO">3.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/full/ByQYZJ">3.1.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer 10-11</td>
+    <td>Internet Explorer (10-11)</td>
   </tr>
 </table>
 
@@ -139,7 +139,7 @@ When using the `flex` shorthand, always include a unit in the `flex-basis` porti
       <a href="http://codepen.io/philipwalton/full/LEbQON">5.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/full/wBoyry">5.1.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer 10-11</td>
+    <td>Internet Explorer (10-11)</td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ This bug can manifest itself in two ways: when not setting any flex values or wh
 
 #### Workaround
 
-If you have to support IE 10, the best solution is to *always* set an explicit `flex-shrink` or `flex` value on all of your flex items. Demo [6.1.a](http://codepen.io/philipwalton/pen/myOYqW) shows how not setting any flexibility properties causes an error, and demo [6.2.a](http://codepen.io/philipwalton/pen/zvvQdB) shows how using `flex: 1` can have the same problem.
+If you have to support IE 10, the best solution is to *always* set an explicit `flex-shrink` value on all of your flex items, or to always use the longhand form (rather than the shorthand) in `flex` declarations to avoid the gotchas shown in the table above. Demo [6.1.a](http://codepen.io/philipwalton/pen/myOYqW) shows how not setting any flexibility properties causes an error, and demo [6.2.a](http://codepen.io/philipwalton/pen/zvvQdB) shows how using `flex: 1` can have the same problem.
 
 ### 7. `flex-basis` doesn't account for `box-sizing:border-box`
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The flexbox spec defines an initial `flex-shrink` value of `1` but says items sh
       <a href="http://codepen.io/philipwalton/pen/ogYpVv">2.1.b</a> &mdash; <em>workaround</em><br>
     </td>
     <td>
-      Internet Explorer 10-11 (fixed in 12+)
+      Internet Explorer 10-11 (fixed in Edge)
     </td>
   </tr>
 </table>
@@ -94,7 +94,7 @@ Most of the time, this can be fixed by simply setting `max-width:100%` on the fl
       <a href="http://codepen.io/philipwalton/pen/KwNvLo">3.1.b</a> &mdash; <em>workaround</em><br>
       <a href="http://codepen.io/philipwalton/pen/VYmbmj">3.2.a</a> &mdash; <em>bug</em><br>
     </td>
-    <td>Internet Explorer 10-11 (fixed in 12+)</td>
+    <td>Internet Explorer 10-11 (fixed in Edge)</td>
     <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625</a></td>
   </tr>
 </table>
@@ -121,7 +121,7 @@ There are cases, however, where no good workaround exists. Demo [3.2.a](http://c
       <a href="http://codepen.io/philipwalton/pen/OPbQgO">3.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/pen/ByQYZJ">3.1.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer 10-11 (fixed in 12+)</td>
+    <td>Internet Explorer 10-11 (fixed in Edge)</td>
   </tr>
 </table>
 
@@ -149,7 +149,7 @@ When using the `flex` shorthand, always include a unit in the `flex-basis` porti
       <a href="http://codepen.io/philipwalton/pen/LEbQON">5.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/pen/wBoyry">5.1.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer 10-11 (fixed in 12+)</td>
+    <td>Internet Explorer 10-11 (fixed in Edge)</td>
   </tr>
 </table>
 
@@ -177,7 +177,7 @@ You can avoid this problem by adding a container element to house the element wi
       <a href="http://codepen.io/philipwalton/pen/myOYqW">6.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/pen/azBrLo">6.1.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer 10 (fixed in 11+)</td>
+    <td>Internet Explorer 10 (fixed in 11)</td>
   </tr>
 </table>
 
@@ -200,7 +200,7 @@ If you have to support IE 10, the best solution is to *always* set an explicit `
       <a href="http://codepen.io/philipwalton/pen/XJMWem">7.1.b</a> &mdash; <em>workaround</em><br>
       <a href="http://codepen.io/philipwalton/pen/ZYLdqb">7.1.c</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer 10-11 (fixed in 12+)</td>
+    <td>Internet Explorer 10-11 (fixed in Edge)</td>
   </tr>
 </table>
 
@@ -227,24 +227,24 @@ There are two ways to work around this bug. The first requires no additional mar
       <a href="http://codepen.io/philipwalton/pen/ogBrye">8.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/pen/bNgPKz">8.1.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer 10-11 (fixed in 12+)</td>
+    <td>Internet Explorer 10-11 (fixed in Edge)</td>
   </tr>
   <tr valign="top">
     <td>
       <a href="http://codepen.io/philipwalton/pen/VYJgJo">8.2.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/pen/pvXGmW">8.2.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer 10 (fixed in 11+)</td>
+    <td>Internet Explorer 10 (fixed in 11)</td>
   </tr>
 </table>
 
 IE 10-11 ignore `calc()` functions used in `flex` shorthand declarations. Demo [8.1.a](http://codepen.io/philipwalton/pen/ogBrye) shows `flex:0 0 calc(100%/3)` not working in IE.
 
-In IE 10, `calc()` functions don't even work in longhand `flex-basis` declarations (though this does work in IE 11+). Demo [8.2.a](http://codepen.io/philipwalton/pen/VYJgJo) shows `flex-basis: calc(100%/3)` not working in IE 10.
+In IE 10, `calc()` functions don't even work in longhand `flex-basis` declarations (though this does work in IE 11). Demo [8.2.a](http://codepen.io/philipwalton/pen/VYJgJo) shows `flex-basis: calc(100%/3)` not working in IE 10.
 
 #### Workaround
 
-Since this bug only affects the `flex` shorthand declaration in IE 11, an easy workaround (if you only need to support IE 11+) is to always specify each flexibility property individually. Demo [8.1.b](http://codepen.io/philipwalton/pen/bNgPKz) offers an example of this.
+Since this bug only affects the `flex` shorthand declaration in IE 11, an easy workaround (if you only need to support IE 11) is to always specify each flexibility property individually. Demo [8.1.b](http://codepen.io/philipwalton/pen/bNgPKz) offers an example of this.
 
 If you need to support IE 10 as well, then you'll need to fall back to setting `width` or `height` (depending on the container's `flex-direction` property). You can do this by setting a `flex-basis` value of `auto`, which will instruct the browser to use the element's [main size](http://dev.w3.org/csswg/css-flexbox/#box-model) property (i.e., its `width` or `height`). Demo [8.2.b](http://codepen.io/philipwalton/pen/pvXGmW) offers an example of this.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 
 1. [Minimum content sizing of flex items not honored](#1-minimum-content-sizing-of-flex-items-not-honored)
 2. [Column flex items set to `align-items:center` overflow their container](#2-column-flex-items-set-to-align-itemscenter-overflow-their-container)
-3. [`min-height` on a column flex container won't apply to its flex items](#3-min-height-on-a-column-flex-container-wont-apply-to-its-flex-items)
+3. [`min-height` on a flex container won't apply to its flex items](#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items)
 4. [`flex` shorthand declarations with unitless `flex-basis` values are ignored](#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored)
 5. [Column flex items don't always preserve intrinsic aspect ratios](#5-column-flex-items-dont-always-preserve-intrinsic-aspect-ratios)
 6. [The default `flex` value has changed](#6-the-default-flex-value-has-changed)
@@ -80,7 +80,7 @@ When using `align-items:center` on a flex container in the column direction, the
 
 Most of the time, this can be fixed by simply setting `max-width:100%` on the flex item. If the flex item has a padding or border set, you'll also need to make sure to use `box-sizing:border-box` to account for that space. If the flex item has a margin, using `box-sizing` alone will not work, so you may need to use a container element with padding instead.
 
-### 3. `min-height` on a column flex container won't apply to its flex items
+### 3. `min-height` on a flex container won't apply to its flex items
 
 <table>
   <tr>
@@ -101,7 +101,7 @@ Most of the time, this can be fixed by simply setting `max-width:100%` on the fl
 
 In order for flex items to size and position themselves, they need to know how big their containers are. For example, if a flex item is supposed to be vertically centered, it needs to know how tall its parent is. The same is true when flex items are told to grow to fill the remaining empty space.
 
-In IE 10-11, `min-height` declarations on flex containers in the column direction work to size the containers themselves, but their flex item children do not seem to know the size of their parents. They act as if no height has been set at all.
+In IE 10-11, `min-height` declarations on flex containers work to size the containers themselves, but their flex item children do not seem to know the size of their parents. They act as if no height has been set at all.
 
 #### Workaround
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 5. [Column flex items don't always preserve intrinsic aspect ratios](#5-column-flex-items-dont-always-preserve-intrinsic-aspect-ratios)
 6. [The default `flex` value has changed](#6-the-default-flex-value-has-changed)
 7. [`flex-basis` doesn't account for `box-sizing:border-box`](#7-flex-basis-doesnt-account-for-box-sizingborder-box)
+8. [`flex` shorthand doesn't support `calc()`](#8-flex-shorthand-doesnt-support-calc)
 
 ### 1. Minimum content sizing of flex items not honored
 
@@ -210,6 +211,28 @@ There are two ways to work around this bug. The first requires no additional mar
 
 1. Instead of setting an explicit `flex-basis` value, use `auto`, and then set an explicit width or height. Demo [7.1.b](http://codepen.io/philipwalton/pen/XJMWem) shows this.
 2. Use a wrapper element that contains no border or padding so it works with the content box model. Demo [7.1.c](http://codepen.io/philipwalton/pen/ZYLdqb) show this.
+
+### 8. `flex` shorthand doesn't support `calc()`
+
+<table>
+  <tr>
+    <th align="left">Demos</th>
+    <th align="left">Browsers affected</th>
+  </tr>
+  <tr valign="top">
+    <td>
+      <a href="http://codepen.io/philipwalton/pen/ogBrye">8.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/bNgPKz">8.1.b</a> &mdash; <em>workaround</em>
+    </td>
+    <td>Internet Explorer 10-11 (fixed in 12+)</td>
+  </tr>
+</table>
+
+Internet Explorer 10-11 ignore `flex` shorthand declarations that use the `calc()` function in their `flex-basis` portion. Demo [8.1.a](http://codepen.io/philipwalton/pen/ogBrye) show how `flex:0 0 calc(100%/3)` breaks in IE.
+
+#### Workaround
+
+This bug only affects the `flex` shorthand, so if you need to use `calc()` make sure to specify each flexibility property individually. Demo [8.1.b](http://codepen.io/philipwalton/pen/bNgPKz) offers an example of this.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 7. [`flex-basis` doesn't account for `box-sizing:border-box`](#7-flex-basis-doesnt-account-for-box-sizingborder-box)
 8. [`flex-basis` doesn't support `calc()`](#8-flex-basis-doesnt-support-calc)
 9. [`<button>` elements can't be flex containers](#9-button-elements-cant-be-flex-containers)
-
+10. [`align-items: baseline` doesn't work with nested flex containers](#align-items-baseline-doesnt-work-with-nested-flex-containers)
 
 ### 1. Minimum content sizing of flex items not honored
 
@@ -274,6 +274,34 @@ Unlike `<input>` elements of type "button" or "submit", the HTML5 `<button>` ele
 #### Workaround
 
 The simple solution to this problem is to use a wrapper element inside of the buton and apply `display:flex` to it. The `<button>` can then be styled as normal.
+
+### 10. `align-items: baseline` doesn't work with nested flex containers
+
+<table>
+  <tr>
+    <th align="left">Demos</th>
+    <th align="left">Browsers affected</th>
+    <th align="left">Tracking bugs</th>
+  </tr>
+  <tr valign="top">
+    <td>
+      <a href="http://codepen.io/philipwalton/pen/vOOejZ">10.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/MwwEVd">10.1.b</a> &mdash; <em>workaround</em>
+    </td>
+    <td>
+      Firefox
+    </td>
+    <td>
+      <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1146442">Firefox #1146442</a>
+    </td>
+  </tr>
+</table>
+
+In Firefox, nested flex containers don't contribute to the baseline that other flex items should align themselves to. Demo [10.1.a](http://codepen.io/philipwalton/pen/vOOejZ) shows the line on the left incorrectly aligning itself to the second line of text on the right. It should be aligned to the first line of text, which is the inner flex container.
+
+#### Workaround
+
+This bug only affects nested containers set to `display: flex`. If you set the nested container to `display: inline-flex` it works as expected. Note that when using `inline-flex` you will probably also need to set the width to `100%`.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ You can avoid this problem by adding a container element to house the element wi
 
 ## Acknowledgements
 
-Flexbugs was created as a follow-up to the article [Normalizing Cross-Browser Flexbox Issues](http://philipwalton.com/articles/normalizing-cross-browser-flexbox-issues/). It's maintained by [@philwalton](https://twitter.com/philwalton) and [@gregwhitworth](https://twitter.com/gregwhitworth). If you have any questions or would like to get involved, please feel free to reach out to either of us on Twitter.
+Flexbugs was created as a follow-up to the article [Normalizing Cross-Browser Flexbox Bugs](http://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/). It's maintained by [@philwalton](https://twitter.com/philwalton) and [@gregwhitworth](https://twitter.com/gregwhitworth). If you have any questions or would like to get involved, please feel free to reach out to either of us on Twitter.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 8. [`flex-basis` doesn't support `calc()`](#8-flex-basis-doesnt-support-calc)
 9. [`<button>` elements can't be flex containers](#9-button-elements-cant-be-flex-containers)
 10. [`align-items: baseline` doesn't work with nested flex containers](#10-align-items-baseline-doesnt-work-with-nested-flex-containers)
-11. [Vertical, percentage-based padding and margins don't work on flex items](#11-vertical-percentage-based-padding-and-margins-dont-work-on-flex-items)
-12. [Min and max size declarations are ignored when wrapping flex items](#12-min-and-max-size-declarations-are-ignored-when-wrapping-flex-items)
+11. [Min and max size declarations are ignored when wrapping flex items](#11-min-and-max-size-declarations-are-ignored-when-wrapping-flex-items)
 
 ### 1. Minimum content sizing of flex items not honored
 
@@ -307,7 +306,8 @@ In Firefox, nested flex containers don't contribute to the baseline that other f
 
 This bug only affects nested containers set to `display: flex`. If you set the nested container to `display: inline-flex` it works as expected. Note that when using `inline-flex` you will probably also need to set the width to `100%`.
 
-### 11. Vertical, percentage-based padding and margins don't work on flex items.
+
+### 11. Min and max size declarations are ignored when wrapping flex items
 
 <table>
   <tr>
@@ -316,30 +316,8 @@ This bug only affects nested containers set to `display: flex`. If you set the n
   </tr>
   <tr valign="top">
     <td>
-      <a href="http://codepen.io/anon/pen/EjjEmW">11.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/anon/pen/vOORJa">11.1.b</a> &mdash; <em>workaround</em>
-    </td>
-    <td>Firefox</td>
-  </tr>
-</table>
-
-Padding and margins, when set in percentages, are always relative to the parent element's width (not height). This is even true for top and bottom padding and margins. In Firefox, when applying a percentage-based padding or margin to the top or bottom of a flex item, the value computes to zero. Demo [11.1.a](http://codepen.io/philipwalton/pen/EjjEmW) shows an example of this.
-
-#### Workaround
-
-This bug only affects flex items, so the solution is to apply any vertical padding or margins to an inner wrapper element. Demo [11.1.b](http://codepen.io/philipwalton/pen/vOORJa) shows an example of this.
-
-### 12. Min and max size declarations are ignored when wrapping flex items
-
-<table>
-  <tr>
-    <th align="left">Demos</th>
-    <th align="left">Browsers affected</th>
-  </tr>
-  <tr valign="top">
-    <td>
-      <a href="http://codepen.io/anon/pen/BNrGwN">12.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/anon/pen/RPMqjz">12.1.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/anon/pen/BNrGwN">11.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/anon/pen/RPMqjz">11.1.b</a> &mdash; <em>workaround</em>
     </td>
     <td>Safari</td>
   </tr>
@@ -347,13 +325,13 @@ This bug only affects flex items, so the solution is to apply any vertical paddi
 
 Safari uses min/max width/height declarations for actually rendering the size of flex items, but it ignores those values when calculating how many items should be on a single line of a multi-line flex container. Instead, it simply uses the item's `flex-basis` value, or its width if the flex basis is set to `auto`.
 
-This is problematic when using the `flex: 1` shorthand because that sets the flex basis to `0%`, and an infinite number of flex items could fit on a single line if the browser thinks their widths are all zero. Demo [12.1.a](http://codepen.io/philipwalton/pen/BNrGwN) show an example of this happening.
+This is problematic when using the `flex: 1` shorthand because that sets the flex basis to `0%`, and an infinite number of flex items could fit on a single line if the browser thinks their widths are all zero. Demo [11.1.a](http://codepen.io/philipwalton/pen/BNrGwN) show an example of this happening.
 
 This is also problematic when creating fluid layouts where you want your flex items to be no bigger than X but no smaller than Y. Since Safari ignores those values when determining how many items fit on a line, that strategy won't work.
 
 #### Workaround
 
-The only way to avoid this issue is to make sure to set the flex basis to a value that is always going to be between (inclusively) the min and max size declarations. If using either a min or a max size declaration, set the flex basis to whatever that value is, if you're using both a min *and* a max size declaration, set the flex basis to a value that is somewhere in that range. This sometimes requires using percentage values or media queries to cover all possible scenarios. Demo [12.1.b](http://codepen.io/philipwalton/pen/RPMqjz) shows an example of setting the flex basis to the same value as the min width to workaround this bug in Safari.
+The only way to avoid this issue is to make sure to set the flex basis to a value that is always going to be between (inclusively) the min and max size declarations. If using either a min or a max size declaration, set the flex basis to whatever that value is, if you're using both a min *and* a max size declaration, set the flex basis to a value that is somewhere in that range. This sometimes requires using percentage values or media queries to cover all possible scenarios. Demo [11.1.b](http://codepen.io/philipwalton/pen/RPMqjz) shows an example of setting the flex basis to the same value as the min width to workaround this bug in Safari.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
     </td>
     <td>
       Chrome (fixed in 44)<br>
-      Opera<br>
+      Opera (fixed in 31)<br>
       Safari
     </td>
     <td>

--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ You can avoid this problem by adding a container element to house the element wi
   <tr valign="top">
     <td>
       <a href="http://codepen.io/philipwalton/pen/myOYqW">6.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/philipwalton/pen/azBrLo">6.1.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/philipwalton/pen/azBrLo">6.1.b</a> &mdash; <em>workaround</em><br>
+      <a href="http://codepen.io/philipwalton/pen/zvvQdB">6.2.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/LppoOj">6.2.b</a> &mdash; <em>workaround</em>
     </td>
     <td>Internet Explorer 10 (fixed in 11)</td>
   </tr>
@@ -186,9 +188,39 @@ You can avoid this problem by adding a container element to house the element wi
 
 When IE 10 was being developed, the [March 2012 spec](http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flexibility) said the initial value for the `flex` property was `none`, which translates to `0 0 auto`. The [most recent spec](http://www.w3.org/TR/css3-flexbox/#flex-property) sets the initial `flex` value to the initial values of the individual flexibility properties, which corresponds to `initial` or `0 1 auto`. Notice that this means IE 10 uses a different initial `flex-shrink` value (technically it was called `neg-flex` in the spec at the time) from every other browser. Other browsers (including IE 11) use an initial value of `1` rather than `0`.
 
+This bug can manifest itself in two ways: when not setting any flex values or when using one of the `flex` shorthands. In both cases, flex items in IE 10 will behave differently from all other browsers. The following table illustrates the difference:
+
+<table>
+  <tr>
+    <th align="left">Declaration</th>
+    <th align="left">What it should mean</th>
+    <th align="left">What it means in IE 10</th>
+  </tr>
+  <tr>
+    <td>(no flex declaration)</td>
+    <td><code>flex: 0 1 auto</code></td>
+    <td><code>flex: 0 0 auto</code></td>
+  </tr>
+  <tr>
+    <td><code>flex: 1</code></td>
+    <td><code>flex: 1 1 0%</code></td>
+    <td><code>flex: 1 0 0px</code></td>
+  </tr>
+  <tr>
+    <td><code>flex: auto</code></td>
+    <td><code>flex: 1 1 auto</code></td>
+    <td><code>flex: 1 0 auto</code></td>
+  </tr>
+  <tr>
+    <td><code>flex: initial</code></td>
+    <td><code>flex: 0 1 auto</code></td>
+    <td><code>flex: 0 0 auto</code></td>
+  </tr>
+</table>
+
 #### Workaround
 
-If you have to support IE 10, the best solution is to *always* set an explicit `flex-shrink` or `flex` value on all of your flex items. Demo [6.1.a](http://codepen.io/philipwalton/pen/myOYqW) shows how not setting any flexibility properties causes an error.
+If you have to support IE 10, the best solution is to *always* set an explicit `flex-shrink` or `flex` value on all of your flex items. Demo [6.1.a](http://codepen.io/philipwalton/pen/myOYqW) shows how not setting any flexibility properties causes an error, and demo [6.2.a](http://codepen.io/philipwalton/pen/zvvQdB) shows how using `flex: 1` can have the same problem.
 
 ### 7. `flex-basis` doesn't account for `box-sizing:border-box`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Flexbugs
 
 This repo aims to be community curated list of cross-browser flexbox issues and known workarounds for them. The goal is that if you're building a website using flexbox and something isn't working as you'd expect, you can find the solution here.
 
-As the spec continues to evolve and vendors nail down their implementations, this repo will be updated with newly discovered issues and remove old issues as their fixed or become obsolete.
+As the spec continues to evolve and vendors nail down their implementations, this repo will be updated with newly discovered issues and remove old issues as they're fixed or become obsolete.
 
 ## The bugs and their workarounds
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 7. [`flex-basis` doesn't account for `box-sizing:border-box`](#7-flex-basis-doesnt-account-for-box-sizingborder-box)
 8. [`flex-basis` doesn't support `calc()`](#8-flex-basis-doesnt-support-calc)
 9. [`<button>` elements can't be flex containers](#9-button-elements-cant-be-flex-containers)
-10. [`align-items: baseline` doesn't work with nested flex containers](#align-items-baseline-doesnt-work-with-nested-flex-containers)
+10. [`align-items: baseline` doesn't work with nested flex containers](#10-align-items-baseline-doesnt-work-with-nested-flex-containers)
 
 ### 1. Minimum content sizing of flex items not honored
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Most of the time, this can be fixed by simply setting `max-width:100%` on the fl
       <a href="http://codepen.io/philipwalton/pen/RNoZJP">3.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/pen/KwNvLo">3.1.b</a> &mdash; <em>workaround</em><br>
       <a href="http://codepen.io/philipwalton/pen/VYmbmj">3.2.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/JdvdJE">3.2.b</a> &mdash; <em>workaround</em>
     </td>
     <td>Internet Explorer 10-11 (fixed in Edge)</td>
     <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625</a></td>
@@ -107,7 +108,7 @@ In IE 10-11, `min-height` declarations on flex containers work to size the conta
 
 By far the most common element to apply `min-height` to is the body element, and usually you're setting it to `100%` (or `100vh`). Since the body element will never have any content below it, and since having a vertical scroll bar appear when there's a lot of content on the page is usually the desired behavior, substituting `height` for `min-height` will almost always work as shown in demo [3.1.b](http://codepen.io/philipwalton/pen/KwNvLo).
 
-There are cases, however, where no good workaround exists. Demo [3.2.a](http://codepen.io/philipwalton/pen/VYmbmj) shows a visual design where `min-height` is truly needed and a `height` substitution will not work. In such cases, you may need to rethink your design or resort to a [browser detection hack](http://stackoverflow.com/questions/20541306/how-to-write-a-css-hack-for-ie-11).
+For cases where `min-height` is required, the workaround is to add a wrapper element around the flex container that is itself a flex container in the column direction. For some reason nested flex containers are not affected by this bug. Demo [3.2.a](http://codepen.io/philipwalton/pen/VYmbmj) shows a visual design where `min-height` is required, and demo [3.2.b](http://codepen.io/philipwalton/pen/JdvdJE) shows how this bug can be avoided with a wrapper element.
 
 ### 4. `flex` shorthand declarations with unitless `flex-basis` values are ignored
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can avoid this problem by adding a container element to house the element wi
   </tr>
 </table>
 
-When IE 10 was being developed, the [March 2012 spec](http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flexibility) said the initial value for the `flex` property was `none`, which translates to `0 0 auto`. The [most recent spec](http://www.w3.org/TR/css3-flexbox/#flex-property) sets the initial `flex` value to the initial values of the individual flexibility properties, which corresponds to `initial` or `0 1 auto`. Notice that this means IE 10 uses a different initial `flex-shrink` value (technically it was called `neg-flex` in the spec at the time) than every other browser. Other browsers (including IE 11) use an initial value of `1` rather than `0`.
+When IE 10 was being developed, the [March 2012 spec](http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flexibility) said the initial value for the `flex` property was `none`, which translates to `0 0 auto`. The [most recent spec](http://www.w3.org/TR/css3-flexbox/#flex-property) sets the initial `flex` value to the initial values of the individual flexibility properties, which corresponds to `initial` or `0 1 auto`. Notice that this means IE 10 uses a different initial `flex-shrink` value (technically it was called `neg-flex` in the spec at the time) from every other browser. Other browsers (including IE 11) use an initial value of `1` rather than `0`.
 
 #### Workaround
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 6. [The default `flex` value has changed](#6-the-default-flex-value-has-changed)
 7. [`flex-basis` doesn't account for `box-sizing:border-box`](#7-flex-basis-doesnt-account-for-box-sizingborder-box)
 8. [`flex-basis` doesn't support `calc()`](#8-flex-basis-doesnt-support-calc)
-9. [`<button>` elements can't be flex containers](#9-button-elements-cant-be-flex-containers)
+9. [Some HTML elements can't be flex containers](#9-some-html-elements-cant-be-flex-containers)
 10. [`align-items: baseline` doesn't work with nested flex containers](#10-align-items-baseline-doesnt-work-with-nested-flex-containers)
 11. [Min and max size declarations are ignored when wrapping flex items](#11-min-and-max-size-declarations-are-ignored-when-wrapping-flex-items)
 12. [Inline elements are not treated as flex-items](#12-inline-elements-are-not-treated-as-flex-items)
@@ -251,7 +251,7 @@ Since this bug only affects the `flex` shorthand declaration in IE 11, an easy w
 
 If you need to support IE 10 as well, then you'll need to fall back to setting `width` or `height` (depending on the container's `flex-direction` property). You can do this by setting a `flex-basis` value of `auto`, which will instruct the browser to use the element's [main size](http://dev.w3.org/csswg/css-flexbox/#box-model) property (i.e., its `width` or `height`). Demo [8.2.b](http://codepen.io/philipwalton/pen/pvXGmW) offers an example of this.
 
-### 9. `<button>` elements can't be flex containers
+### 9. Some HTML elements can't be flex containers
 
 <table>
   <tr>
@@ -262,10 +262,16 @@ If you need to support IE 10 as well, then you'll need to fall back to setting `
   <tr valign="top">
     <td>
       <a href="http://codepen.io/philipwalton/pen/ByZgpW">9.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/philipwalton/pen/mywZpr">9.1.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/philipwalton/pen/mywZpr">9.1.b</a> &mdash; <em>workaround</em><br>
+      <a href="http://codepen.io/philipwalton/pen/wKBqdY">9.2.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/EVaRaX">9.2.b</a> &mdash; <em>workaround</em>
     </td>
     <td>
-      Firefox
+      Chrome<br>
+      Edge<br>
+      Firefox<br>
+      Opera<br>
+      Safari
     </td>
     <td>
       <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=984869">Firefox #984869</a>
@@ -273,12 +279,13 @@ If you need to support IE 10 as well, then you'll need to fall back to setting `
   </tr>
 </table>
 
-Unlike `<input>` elements of type "button" or "submit", the HTML5 `<button>` element can contain child nodes. This allows you to put things other than text (e.g. icons) inside of `<button>` elements without having to resort to using semantically incorrect tags like `<div>` or `<a>`. Firefox, however, does not allow the `<button>` element to be a flex container.
+Certain HTML elements, like `<fieldset>` and `<button>`, do not work as flex containers. The browsers default rendering of those element's UI conflicts with the `display: flex` declaration.
+
+Demo [9.1.a](http://codepen.io/philipwalton/pen/ByZgpW) shows how `<button>` elements don't work in Firefox, and demo [9.2.a](http://codepen.io/philipwalton/pen/wKBqdY) shows that `<fieldset>` elements don't work in most browsers.
 
 #### Workaround
 
-The simple solution to this problem is to use a wrapper element inside of the button and apply `display:flex` to it. The `<button>` can then be styled as normal.
-
+The simple solution to this problem is to use a wrapper element that can be a flex container (like a `<div>`) directly inside of the element that can't. Demos [9.1.b](http://codepen.io/philipwalton/pen/mywZpr) and [9.2.b](http://codepen.io/philipwalton/pen/EVaRaX) show workaround for the `<button>` and `<fieldset>` elements, respectively.
 
 ### 10. `align-items: baseline` doesn't work with nested flex containers
 
@@ -356,7 +363,7 @@ The only way to avoid this issue is to make sure to set the flex basis to a valu
   </tr>
 </table>
 
-Inline element, including `::before` and `::after` pseudo-elements, are not treated as flex items in IE 10. IE 11 fixed this bug with regular inline element, but it still affects the `::before` and `::after` pseudo-elements.
+Inline elements, including `::before` and `::after` pseudo-elements, are not treated as flex items in IE 10. IE 11 fixed this bug with regular inline element, but it still affects the `::before` and `::after` pseudo-elements.
 
 #### Workaround
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 8. [`flex-basis` doesn't support `calc()`](#8-flex-basis-doesnt-support-calc)
 9. [`<button>` elements can't be flex containers](#9-button-elements-cant-be-flex-containers)
 10. [`align-items: baseline` doesn't work with nested flex containers](#10-align-items-baseline-doesnt-work-with-nested-flex-containers)
-11. [vertical `padding` and `margin` are not applied if set in percents on flex elements](#11-vertical-padding-and-margin-are-not-applied-if-set-in-percents-on-flex-elements)
+11. [Vertical, percentage-based padding and margins don't work on flex items](#11-vertical-percentage-based-padding-and-margins-dont-work-on-flex-items)
 
 ### 1. Minimum content sizing of flex items not honored
 
@@ -306,7 +306,7 @@ In Firefox, nested flex containers don't contribute to the baseline that other f
 
 This bug only affects nested containers set to `display: flex`. If you set the nested container to `display: inline-flex` it works as expected. Note that when using `inline-flex` you will probably also need to set the width to `100%`.
 
-### 11. vertical `padding` and `margin` are not applied if set in percents on flex elements
+### 11. Vertical, percentage-based padding and margins don't work on flex items.
 
 <table>
   <tr>
@@ -315,19 +315,18 @@ This bug only affects nested containers set to `display: flex`. If you set the n
   </tr>
   <tr valign="top">
     <td>
-      <a href="http://codepen.io/anon/pen/WvNqoQ">11.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/anon/pen/yNLdVV?editors=110">11.1.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/anon/pen/EjjEmW">11.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/anon/pen/vOORJa">11.1.b</a> &mdash; <em>workaround</em>
     </td>
     <td>Firefox</td>
   </tr>
 </table>
 
-Vertical padding & margin when set in percent units is not interpreted by Firefox on flex elements.
+Padding and margins, when set in percentages, are always relative to the parent element's width (not height). This is even true for top and bottom padding and margins. In Firefox, when applying a percentage-based padding or margin to the top or bottom of a flex item, the value computes to zero. Demo [11.1.a](http://codepen.io/philipwalton/pen/EjjEmW) shows an example of this.
 
 #### Workaround
 
-The solution to this issue is to wrap the element with a relative padding and apply the flex properties to it.
-
+This bug only affects flex items, so the solution is to apply any vertical padding or margins to an inner wrapper element. Demo [11.1.b](http://codepen.io/philipwalton/pen/vOORJa) shows an example of this.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 9. [`<button>` elements can't be flex containers](#9-button-elements-cant-be-flex-containers)
 10. [`align-items: baseline` doesn't work with nested flex containers](#10-align-items-baseline-doesnt-work-with-nested-flex-containers)
 11. [Vertical, percentage-based padding and margins don't work on flex items](#11-vertical-percentage-based-padding-and-margins-dont-work-on-flex-items)
+12. [Min and max size declarations are ignored when wrapping flex items](#12-min-and-max-size-declarations-are-ignored-when-wrapping-flex-items)
 
 ### 1. Minimum content sizing of flex items not honored
 
@@ -327,6 +328,32 @@ Padding and margins, when set in percentages, are always relative to the parent 
 #### Workaround
 
 This bug only affects flex items, so the solution is to apply any vertical padding or margins to an inner wrapper element. Demo [11.1.b](http://codepen.io/philipwalton/pen/vOORJa) shows an example of this.
+
+### 12. Min and max size declarations are ignored when wrapping flex items
+
+<table>
+  <tr>
+    <th align="left">Demos</th>
+    <th align="left">Browsers affected</th>
+  </tr>
+  <tr valign="top">
+    <td>
+      <a href="http://codepen.io/anon/pen/BNrGwN">12.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/anon/pen/RPMqjz">12.1.b</a> &mdash; <em>workaround</em>
+    </td>
+    <td>Safari</td>
+  </tr>
+</table>
+
+Safari uses min/max width/height declarations for actually rendering the size of flex items, but it ignores those values when calculating how many items should be on a single line of a multi-line flex container. Instead, it simply uses the item's `flex-basis` value, or its width if the flex basis is set to `auto`.
+
+This is problematic when using the `flex: 1` shorthand because that sets the flex basis to `0%`, and an infinite number of flex items could fit on a single line if the browser thinks their widths are all zero.
+
+This is also problematic when creating fluid layouts where you want your flex items to be no bigger than X but no smaller than Y. Since Safari ignores those values when determining how many items fit on a line, that strategy won't work.
+
+#### Workaround
+
+The only way to avoid this issue is to make sure to set the flex basis to a value that is always going to be between (inclusively) the min and max size declarations. If using either a min or a max size declaration, set the flex basis to whatever that value is, if you're using both a min *and* a max size declaration, set the flex basis to a value that is somewhere in that range. This sometimes requires using percentage values or media queries to cover all possible scenarios. Demo [12.1.b](http://codepen.io/philipwalton/pen/RPMqjz) shows an example of setting the flex basis to the same value as the min width to workaround this bug in Safari.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Flexbugs
 ========
 
-This repo aims to be a community curated list of cross-browser flexbox issues and known workarounds for them. The goal is that if you're building a website using flexbox and something isn't working as you'd expect, you can find the solution here.
+This repository is a community-curated list of flexbox issues and cross-browser workarounds for them. The goal is that if you're building a website using flexbox and something isn't working as you'd expect, you can find the solution here.
 
-As the spec continues to evolve and vendors nail down their implementations, this repo will be updated with newly discovered issues and remove old issues as they're fixed or become obsolete.
+As the spec continues to evolve and vendors nail down their implementations, this repo will be updated with newly discovered issues and remove old issues as they're fixed or become obsolete. If you discover a bug that's not listed here, please [report it](#contributing) so everyone else can benefit.
 
 ## The bugs and their workarounds
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ This bug only affects nested containers set to `display: flex`. If you set the n
   <tr>
     <th align="left">Demos</th>
     <th align="left">Browsers affected</th>
+    <th align="left">Tracking bugs</th>
   </tr>
   <tr valign="top">
     <td>
@@ -323,6 +324,9 @@ This bug only affects nested containers set to `display: flex`. If you set the n
       <a href="http://codepen.io/anon/pen/RPMqjz">11.1.b</a> &mdash; <em>workaround</em>
     </td>
     <td>Safari</td>
+    <td>
+      <a href="https://bugs.webkit.org/show_bug.cgi?id=136041">Safari #136041</a>
+    </td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ As the spec continues to evolve and vendors nail down their implementations, thi
     </td>
     <td>
       <a href="https://code.google.com/p/chromium/issues/detail?id=426898">Chrome #426898</a><br>
-      <a href="https://bugs.webkit.org/show_bug.cgi?id=136754">Safari #136754</a><br>
-      <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1043520">Firefox #1043520</a>
+      <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1043520">Firefox #1043520</a><br>
+      <a href="https://bugs.webkit.org/show_bug.cgi?id=136754">Safari #136754</a>
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ According to the [current flexbox specification](http://www.w3.org/TR/css-flexbo
 
 #### Workaround
 
-The flexbox spec defines an initial `flex-shrink` value of `1` but says items should not shrink below their default minimum content size. You can get pretty much this exact same behavior by using a `flex-shrink` value of `0` instead of the default `1`. If your element is already being sized based on its children, and it hasn't set a `width`, `height`, or `flex-basis` value, then setting `flex-shrink:0` will render it the same way&mdash;but it will avoid this bug.
+The flexbox spec defines an initial `flex-shrink` value of `1` but says items should not shrink below their default minimum content size. You can usually get this same behavior by setting a `flex-shrink` value of `0` (instead of the default `1`) and a `flex-basis` value of `auto`. That will cause the flex item to be at least as big as its width or height (if declared) or its default content size.
 
 ### 2. Column flex items set to `align-items:center` overflow their container
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The flexbox spec defines an initial `flex-shrink` value of `1` but says items sh
       <a href="http://codepen.io/philipwalton/pen/ogYpVv">2.1.b</a> &mdash; <em>workaround</em><br>
     </td>
     <td>
-      Internet Explorer (10-11; fixed in 12)
+      Internet Explorer 10-11 (fixed in 12+)
     </td>
   </tr>
 </table>
@@ -90,7 +90,7 @@ Most of the time, this can be fixed by simply setting `max-width:100%` on the fl
       <a href="http://codepen.io/philipwalton/pen/KwNvLo">3.1.b</a> &mdash; <em>workaround</em><br>
       <a href="http://codepen.io/philipwalton/pen/VYmbmj">3.2.a</a> &mdash; <em>bug</em><br>
     </td>
-    <td>Internet Explorer (10-11; fixed in 12)</td>
+    <td>Internet Explorer 10-11 (fixed in 12+)</td>
     <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625</a></td>
   </tr>
 </table>
@@ -117,7 +117,7 @@ There are cases, however, where no good workaround exists. Demo [3.2.a](http://c
       <a href="http://codepen.io/philipwalton/pen/OPbQgO">3.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/pen/ByQYZJ">3.1.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer (10-11; fixed in 12)</td>
+    <td>Internet Explorer 10-11 (fixed in 12+)</td>
   </tr>
 </table>
 
@@ -145,7 +145,7 @@ When using the `flex` shorthand, always include a unit in the `flex-basis` porti
       <a href="http://codepen.io/philipwalton/pen/LEbQON">5.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/pen/wBoyry">5.1.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer (10-11; fixed in 12)</td>
+    <td>Internet Explorer 10-11 (fixed in 12+)</td>
   </tr>
 </table>
 
@@ -173,7 +173,7 @@ You can avoid this problem by adding a container element to house the element wi
       <a href="http://codepen.io/philipwalton/pen/myOYqW">6.1.a</a> &mdash; <em>bug</em><br>
       <a href="http://codepen.io/philipwalton/pen/azBrLo">6.1.b</a> &mdash; <em>workaround</em>
     </td>
-    <td>Internet Explorer (10)</td>
+    <td>Internet Explorer 10 (fixed in 11+)</td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 6. [The default `flex` value has changed](#6-the-default-flex-value-has-changed)
 7. [`flex-basis` doesn't account for `box-sizing:border-box`](#7-flex-basis-doesnt-account-for-box-sizingborder-box)
 8. [`flex` shorthand doesn't support `calc()`](#8-flex-shorthand-doesnt-support-calc)
+9. [`<button>` elements can't be flex containers](#9-button-elements-cant-be-flex-containers)
+
 
 ### 1. Minimum content sizing of flex items not honored
 
@@ -233,6 +235,34 @@ Internet Explorer 10-11 ignore `flex` shorthand declarations that use the `calc(
 #### Workaround
 
 This bug only affects the `flex` shorthand, so if you need to use `calc()` make sure to specify each flexibility property individually. Demo [8.1.b](http://codepen.io/philipwalton/pen/bNgPKz) offers an example of this.
+
+### 9. `<button>` elements can't be flex containers
+
+<table>
+  <tr>
+    <th align="left">Demos</th>
+    <th align="left">Browsers affected</th>
+    <th align="left">Tracking bugs</th>
+  </tr>
+  <tr valign="top">
+    <td>
+      <a href="http://codepen.io/philipwalton/pen/ByZgpW">9.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/mywZpr">9.1.b</a> &mdash; <em>workaround</em>
+    </td>
+    <td>
+      Firefox
+    </td>
+    <td>
+      <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=984869">Firefox #984869</a>
+    </td>
+  </tr>
+</table>
+
+Unlike `<input>` elements of type "button" or "submit", the HTML5 `<button>` element can contain child nodes. This allows you to put things other than text (e.g. icons) inside of `<button>` elements without having to resort to using semantically incorrect tags like `<div>` or `<a>`. Firefox, however, does not allow the `<button>` element to be a flex container.
+
+#### Workaround
+
+The simple solution to this problem is to use a wrapper element inside of the buton and apply `display:flex` to it. The `<button>` can then be styled as normal.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ As the spec continues to evolve and vendors nail down their implementations, thi
     </td>
     <td>
       <a href="https://code.google.com/p/chromium/issues/detail?id=426898">Chrome #426898</a><br>
-      <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1043520">Firefox #1043520</a><br>
       <a href="https://bugs.webkit.org/show_bug.cgi?id=146020">Safari #146020</a>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
     <td>
       <a href="https://code.google.com/p/chromium/issues/detail?id=426898">Chrome #426898</a><br>
       <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1043520">Firefox #1043520</a><br>
-      <a href="https://bugs.webkit.org/show_bug.cgi?id=136754">Safari #136754</a>
+      <a href="https://bugs.webkit.org/show_bug.cgi?id=146020">Safari #146020</a>
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ If you need to support IE 10 as well, then you'll need to fall back to setting `
       Safari
     </td>
     <td>
+      <a href="https://code.google.com/p/chromium/issues/detail?id=262679">Chrome #262679</a><br>
       <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=984869">Firefox #984869</a>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ As the spec continues to evolve and vendors nail down their implementations, thi
   </tr>
   <tr valign="top">
     <td>
-      <a href="http://codepen.io/philipwalton/full/MYbrrr">1.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/philipwalton/full/ByQJOQ">1.1.b</a> &mdash; <em>workaround</em><br>
-      <a href="http://codepen.io/philipwalton/full/ByQJqQ">1.2.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/philipwalton/full/wBopYg">1.2.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/philipwalton/pen/MYbrrr">1.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/ByQJOQ">1.1.b</a> &mdash; <em>workaround</em><br>
+      <a href="http://codepen.io/philipwalton/pen/ByQJqQ">1.2.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/wBopYg">1.2.b</a> &mdash; <em>workaround</em>
     </td>
     <td>
       Chrome<br>
@@ -54,8 +54,8 @@ The flexbox spec defines an initial `flex-shrink` value of `1` but says items sh
   </tr>
   <tr valign="top">
     <td>
-      <a href="http://codepen.io/philipwalton/full/xbRpMe">2.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/philipwalton/full/ogYpVv">2.1.b</a> &mdash; <em>workaround</em><br>
+      <a href="http://codepen.io/philipwalton/pen/xbRpMe">2.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/ogYpVv">2.1.b</a> &mdash; <em>workaround</em><br>
     </td>
     <td>
       Internet Explorer (10-11)
@@ -79,9 +79,9 @@ Most of the time, this can be fixed by simply setting `max-width:100%` on the fl
   </tr>
   <tr valign="top">
     <td>
-      <a href="http://codepen.io/philipwalton/full/RNoZJP">3.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/philipwalton/full/KwNvLo">3.1.b</a> &mdash; <em>workaround</em><br>
-      <a href="http://codepen.io/philipwalton/full/VYmbmj">3.2.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/RNoZJP">3.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/KwNvLo">3.1.b</a> &mdash; <em>workaround</em><br>
+      <a href="http://codepen.io/philipwalton/pen/VYmbmj">3.2.a</a> &mdash; <em>bug</em><br>
     </td>
     <td>Internet Explorer (10-11)</td>
     <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">connect.microsoft.com</a></td>
@@ -94,9 +94,9 @@ In IE 10-11, `min-height` declarations on flex containers in the column directio
 
 #### Workaround
 
-By far the most common element to apply `min-height` to is the body element, and usually you're setting it to `100%` (or `100vh`). Since the body element will never have any content below it, and since having a vertical scroll bar appear when there's a lot of content on the page is usually the desired behavior, substituting `height` for `min-height` will almost always work as shown in demo [3.1.b](http://codepen.io/philipwalton/full/KwNvLo).
+By far the most common element to apply `min-height` to is the body element, and usually you're setting it to `100%` (or `100vh`). Since the body element will never have any content below it, and since having a vertical scroll bar appear when there's a lot of content on the page is usually the desired behavior, substituting `height` for `min-height` will almost always work as shown in demo [3.1.b](http://codepen.io/philipwalton/pen/KwNvLo).
 
-There are cases, however, where no good workaround exists. Demo [3.2.a](http://codepen.io/philipwalton/full/VYmbmj) shows a visual design where `min-height` is truly needed and a `height` substitution will not work. In such cases, you may need to rethink your design or resort to a [browser detection hack](http://stackoverflow.com/questions/20541306/how-to-write-a-css-hack-for-ie-11).
+There are cases, however, where no good workaround exists. Demo [3.2.a](http://codepen.io/philipwalton/pen/VYmbmj) shows a visual design where `min-height` is truly needed and a `height` substitution will not work. In such cases, you may need to rethink your design or resort to a [browser detection hack](http://stackoverflow.com/questions/20541306/how-to-write-a-css-hack-for-ie-11).
 
 ### 4. `flex` shorthand declarations with unitless `flex-basis` values are ignored
 
@@ -107,8 +107,8 @@ There are cases, however, where no good workaround exists. Demo [3.2.a](http://c
   </tr>
   <tr valign="top">
     <td>
-      <a href="http://codepen.io/philipwalton/full/OPbQgO">3.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/philipwalton/full/ByQYZJ">3.1.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/philipwalton/pen/OPbQgO">3.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/ByQYZJ">3.1.b</a> &mdash; <em>workaround</em>
     </td>
     <td>Internet Explorer (10-11)</td>
   </tr>
@@ -135,8 +135,8 @@ When using the `flex` shorthand, always include a unit in the `flex-basis` porti
   </tr>
   <tr valign="top">
     <td>
-      <a href="http://codepen.io/philipwalton/full/LEbQON">5.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/philipwalton/full/wBoyry">5.1.b</a> &mdash; <em>workaround</em>
+      <a href="http://codepen.io/philipwalton/pen/LEbQON">5.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/wBoyry">5.1.b</a> &mdash; <em>workaround</em>
     </td>
     <td>Internet Explorer (10-11)</td>
   </tr>
@@ -146,7 +146,7 @@ The [March 2014 spec](http://www.w3.org/TR/2014/WD-css-flexbox-1-20140325/#min-s
 
 > On a flex item whose overflow is not visible, this [auto] keyword specifies as the minimum size the smaller of: (a) the min-content size, or (b) the computed width/height, if that value is definite.
 
-Demo [5.1.a](http://codepen.io/philipwalton/full/LEbQON) contains an image whose height is 200 pixels and whose width is 500 pixels. Its container, however, is only 300 pixels wide, so after the image is scaled to fit into that space, its computed height should only be 120 pixels. The text quoted above does not make it clear as to whether the flex item's min-content size should be based the image's actual height or scaled height.
+Demo [5.1.a](http://codepen.io/philipwalton/pen/LEbQON) contains an image whose height is 200 pixels and whose width is 500 pixels. Its container, however, is only 300 pixels wide, so after the image is scaled to fit into that space, its computed height should only be 120 pixels. The text quoted above does not make it clear as to whether the flex item's min-content size should be based the image's actual height or scaled height.
 
 The [most recent spec](http://dev.w3.org/csswg/css-flexbox/#min-size-auto) has resolved this ambiguity in favor of using sizes that will preserve an element's intrinsic aspect ratio.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 4. [`flex` shorthand declarations with unitless `flex-basis` values are ignored](#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored)
 5. [Column flex items don't always preserve intrinsic aspect ratios](#5-column-flex-items-dont-always-preserve-intrinsic-aspect-ratios)
 6. [The default `flex` value has changed](#6-the-default-flex-value-has-changed)
-
+7. [`flex-basis` doesn't account for `box-sizing:border-box`](#user-content-7-flex-basis-doesnt-account-for-box-sizingborder-box)
 
 ### 1. Minimum content sizing of flex items not honored
 
@@ -182,6 +182,34 @@ When IE 10 was being developed, the [March 2012 spec](http://www.w3.org/TR/2012/
 #### Workaround
 
 If you have to support IE 10, the best solution is to *always* set an explicit `flex-shrink` or `flex` value on all of your flex items. Demo [6.1.a](http://codepen.io/philipwalton/pen/myOYqW) shows how not setting any flexibility properties causes an error.
+
+### 7. `flex-basis` doesn't account for `box-sizing:border-box`
+
+<table>
+  <tr>
+    <th align="left">Demos</th>
+    <th align="left">Browsers affected</th>
+  </tr>
+  <tr valign="top">
+    <td>
+      <a href="http://codepen.io/philipwalton/pen/JoWjyb">7.1.a</a> &mdash; <em>bug</em><br>
+      <a href="http://codepen.io/philipwalton/pen/XJMWem">7.1.b</a> &mdash; <em>workaround</em><br>
+      <a href="http://codepen.io/philipwalton/pen/ZYLdqb">7.1.c</a> &mdash; <em>workaround</em>
+    </td>
+    <td>Internet Explorer 10-11 (fixed in 12+)</td>
+  </tr>
+</table>
+
+An explicit `flex-basis` value (i.e., any value other than `auto`) is supposed to act just like `width` or `height`. It determines the initial size of a flex item and then the other flexibility properties allow it to grow or shrink accordingly.
+
+Internet Explorer 10-11 always assume a content box model when using `flex-basis` to determine a flex item's size, even if that item is set to `box-sizing:border-box`. Demo [7.1.a](http://codepen.io/philipwalton/pen/JoWjyb) shows that an item with a `flex-basis` value of `100%` will overflow its container by the amount of its border plus its padding.
+
+#### Workaround
+
+There are two ways to work around this bug. The first requires no additional markup, but the second is slightly more flexible:
+
+1. Instead of setting an explicit `flex-basis` value, use `auto`, and then set an explicit width or height. Demo [7.1.b](http://codepen.io/philipwalton/pen/XJMWem) shows this.
+2. Use a wrapper element that contains no border or padding so it works with the content box model. Demo [7.1.c](http://codepen.io/philipwalton/pen/ZYLdqb) show this.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
   <tr>
     <th align="left">Demos</th>
     <th align="left">Browsers affected</th>
+    <th align="left">Tracking bugs</th>
   </tr>
   <tr valign="top">
     <td>
@@ -31,6 +32,10 @@ As the spec continues to evolve and vendors nail down their implementations, thi
       Chrome<br>
       Opera<br>
       Safari
+    </td>
+    <td>
+      <a href="https://code.google.com/p/chromium/issues/detail?id=426898">Chrome #426898</a><br>
+      <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1043520">Firefox #1043520</a>
     </td>
   </tr>
 </table>
@@ -75,7 +80,7 @@ Most of the time, this can be fixed by simply setting `max-width:100%` on the fl
   <tr>
     <th align="left">Demos</th>
     <th align="left">Browsers affected</th>
-    <th align="left">Bug Reports</th>
+    <th align="left">Tracking bugs</th>
   </tr>
   <tr valign="top">
     <td>
@@ -84,7 +89,7 @@ Most of the time, this can be fixed by simply setting `max-width:100%` on the fl
       <a href="http://codepen.io/philipwalton/pen/VYmbmj">3.2.a</a> &mdash; <em>bug</em><br>
     </td>
     <td>Internet Explorer (10-11)</td>
-    <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">connect.microsoft.com</a></td>
+    <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The flexbox spec defines an initial `flex-shrink` value of `1` but says items sh
   <tr valign="top">
     <td>
       <a href="http://codepen.io/philipwalton/pen/xbRpMe">2.1.a</a> &mdash; <em>bug</em><br>
-      <a href="http://codepen.io/philipwalton/pen/ogYpVv">2.1.b</a> &mdash; <em>workaround</em><br>
+      <a href="http://codepen.io/philipwalton/pen/ogYpVv">2.1.b</a> &mdash; <em>workaround</em>
     </td>
     <td>
       Internet Explorer 10-11 (fixed in Edge)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
       <a href="http://codepen.io/philipwalton/pen/wBopYg">1.2.b</a> &mdash; <em>workaround</em>
     </td>
     <td>
-      Chrome<br>
+      Chrome (fixed in 44)<br>
       Opera<br>
       Safari
     </td>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ As the spec continues to evolve and vendors nail down their implementations, thi
     </td>
     <td>
       Chrome<br>
-      Internet Explorer (10-11)<br>
       Opera<br>
       Safari
     </td>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Flexbugs
 ========
 
-This repo aims to be community curated list of cross-browser flexbox issues and known workarounds for them. The goal is that if you're building a website using flexbox and something isn't working as you'd expect, you can find the solution here.
+This repo aims to be a community curated list of cross-browser flexbox issues and known workarounds for them. The goal is that if you're building a website using flexbox and something isn't working as you'd expect, you can find the solution here.
 
 As the spec continues to evolve and vendors nail down their implementations, this repo will be updated with newly discovered issues and remove old issues as they're fixed or become obsolete.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ As the spec continues to evolve and vendors nail down their implementations, thi
 4. [`flex` shorthand declarations with unitless `flex-basis` values are ignored](#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored)
 5. [Flex items in the column direction don't always preserve intrinsic aspect ratios](#5-flex-items-in-the-column-direction-dont-always-preserve-intrinsic-aspect-ratios)
 
-
-## 1. Minimum content sizing of flex items not honored
+### 1. Minimum content sizing of flex items not honored
 
 <table>
   <tr>
@@ -43,11 +42,11 @@ According to the [flexbox specification](http://www.w3.org/TR/css-flexbox/#flex-
 
 > By default, flex items won’t shrink below their minimum content size (the length of the longest word or fixed-size element). To change this, set the min-width or min-height property.
 
-### Workaround
+#### Workaround
 
 The flexbox spec defines an initial `flex-shrink` value of `1` but says items should not shrink below their default minimum content size. You can get pretty much this exact same behavior by using a `flex-shrink` value of `0` instead of the default `1`. If your element is already being sized based on its children, and it hasn't set a `width`, `height`, or `flex-basis` value, then setting `flex-shrink:0` will render it the same way&mdash;but it will avoid this bug.
 
-## 2. Column direction flex items set to `align-items:center` overflow their container
+### 2. Column direction flex items set to `align-items:center` overflow their container
 
 <table>
   <tr>
@@ -67,11 +66,11 @@ The flexbox spec defines an initial `flex-shrink` value of `1` but says items sh
 
 When using `align-items:center` on a flex container in the column direction, the contents of flex item, if too big on one line, will overflow their container in IE 10-11.
 
-### Workaround
+#### Workaround
 
 Most of the time, this can be fixed by simply setting `max-width:100%` on the flex item. If the flex item has a padding or border set, you'll also need to make sure to use `box-sizing:border-box` to account for that space. If the flex item has a margin, using `box-sizing` alone will not work, so you may need to use a container element with a padding instead.
 
-## 3. `min-height` on a flex container won't apply to its flex items
+### 3. `min-height` on a flex container won't apply to its flex items
 
 <table>
   <tr>
@@ -94,13 +93,13 @@ In order for flex items to size and position themselves, they need to know how b
 
 In IE 10-11, `min-height` declarations on flex containers in the column direction work to size the containers themselves, but their flex item children do not seem to know this information. They act as if no height has been set.
 
-### Workaround
+#### Workaround
 
 By far the most common element to apply `min-height` to is the body element, and usually you're setting it to `100%` (or `100vh`). Since the body element will never have contents below it, and since having a vertical scroll bar appear when there's a lot of content on the page is usually the desired behavior, substituting `height` for `min-height` will almost always work. Demo [3.1.b](http://codepen.io/philipwalton/full/KwNvLo) shows the solution to [3.1.a](http://codepen.io/philipwalton/full/RNoZJP).
 
 There are cases, however, where no good workaround exists. Demo [3.2.a] shows a visual design where `min-height` is truly needed and a `height` substitution will not work. In such cases, you may need to rethink your design or resort to a [browser detection hack](http://stackoverflow.com/questions/20541306/how-to-write-a-css-hack-for-ie-11).
 
-## 4. `flex` shorthand declarations with unitless `flex-basis` values are ignored
+### 4. `flex` shorthand declarations with unitless `flex-basis` values are ignored
 
 <table>
   <tr>
@@ -122,13 +121,13 @@ Prior to the release of IE 10, the [flexbox spec at the time](http://www.w3.org/
 
 This is no longer true in the spec, but IE 10-11 still treat it as true. If you use the declaration `flex: 1 0 0` in one of these browsers, it will be an error and the entire rule (including all the flexibility properties) will be ignored.
 
-### Workaround
+#### Workaround
 
 When using the `flex` shorthand, always include a unit in the flex-basis portion. For example: `1 0 0%`.
 
 **Important:** using a `flex` value of something like `1 0 0px` can still be a problem because many CSS minifiers will convert `0px` to `0`. To avoid this, make sure to use `0%` instead of `0px` since most minifiers won't touch percentage values for other reasons.
 
-## 5. Flex items in the column direction don't always preserve intrinsic aspect ratios
+### 5. Flex items in the column direction don't always preserve intrinsic aspect ratios
 
 <table>
   <tr>
@@ -152,14 +151,14 @@ Demo [5.1.a](http://codepen.io/philipwalton/full/LEbQON) contains an image whose
 
 The [most recent spec](http://dev.w3.org/csswg/css-flexbox/#min-size-auto) has resolved this ambiguity in favor of using sizes that will preserve an element's intrinsic aspect ratio.
 
-### Workaround
+#### Workaround
 
 This problem can easily be avoided by adding a container element to house the element with the intrinsic aspect ratio. Since doing this causes the element with the intrinsic aspect ratio to no longer be a flex item, it will be sized as normal.
 
-# Acknowledgements
+## Acknowledgements
 
-Flexbugs was created as a follow-up to the article [Normalizing Cross-Browser Flexbox Issues](#http://philipwalton.com/articles/normalizing-cross-browser-flexbox-issues/). It's maintained by [@philwalton](https://twitter.com/philwalton) and [@gregwhitworth](https://twitter.com/gregwhitworth). If you have any questions or would like to get involved, please feel free to reach out to either of us on Twitter.
+Flexbugs was created as a follow-up to the article [Normalizing Cross-Browser Flexbox Issues](http://philipwalton.com/articles/normalizing-cross-browser-flexbox-issues/). It's maintained by [@philwalton](https://twitter.com/philwalton) and [@gregwhitworth](https://twitter.com/gregwhitworth). If you have any questions or would like to get involved, please feel free to reach out to either of us on Twitter.
 
-# Contributing
+## Contributing
 
 If you've discovered a flexbox bug or would like to submit a workaround, please open an issue or submit a pull request. Make sure to submit relevant test cases and screenshots and indicate which browsers are affected by the issue.

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ This is also problematic when creating fluid layouts where you want your flex it
 
 The only way to avoid this issue is to make sure to set the flex basis to a value that is always going to be between (inclusively) the min and max size declarations. If using either a min or a max size declaration, set the flex basis to whatever that value is, if you're using both a min *and* a max size declaration, set the flex basis to a value that is somewhere in that range. This sometimes requires using percentage values or media queries to cover all possible scenarios. Demo [12.1.b](http://codepen.io/philipwalton/pen/RPMqjz) shows an example of setting the flex basis to the same value as the min width to workaround this bug in Safari.
 
-## Acknowledgements
+## Acknowledgments
 
 Flexbugs was created as a follow-up to the article [Normalizing Cross-Browser Flexbox Bugs](http://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/). It's maintained by [@philwalton](https://twitter.com/philwalton) and [@gregwhitworth](https://twitter.com/gregwhitworth). If you have any questions or would like to get involved, please feel free to reach out to either of us on Twitter.
 


### PR DESCRIPTION
I think I may have found a new flexbox bug. I have a flex container that is too small to hold the flex items. I am using the CSS property "justify-content: space-around". 

According to the specs, the packed items should break out of the container and overflow equally on both sides. That is, it should behave just like "justify-content: center". And that happens with Chrome and Firefox.

But with Internet Explorer 11, the packed items start inside the left edge of the flex container and only break out on the right side. It behaves like "justify-content: flex-start". This is not what is described in the specs at: https://drafts.csswg.org/css-flexbox/#justify-content-property .

Here's the code:

<style>
        html {
            box-sizing: border-box;
        }

        *, *:before, *:after {
            box-sizing: inherit;
        }

        .container {
            background-color: wheat;
            font-size: 2rem;
            font-family: arial;
            font-weight: bold;
            width: 310px;
        }

        .item {
            padding: 10px;
            color: white;
        }    

        .color1 {background-color: red;}
        .color2 {background-color: green;}
        .color3 {background-color: blue;}
        .color4 {background-color: indigo;}
        .color5 {background-color: violet;} 
        .color6 {background-color: darkslategray;}

        .container {
            margin: 5px 50px;
            width: 150px;
            padding: 10px 0px;
        }

        .container-flex {
            display: flex;
            justify-content: space-around; /* Identical to center */
        }
    </style>

    <div class="container container-flex">
        <span class="item color1">1</span>
        <span class="item color2">2</span>
        <span class="item color3">3</span>
        <span class="item color4">4</span>
        <span class="item color5">5</span>
        <span class="item color6">6</span>
    </div>
