### PR TITLE
Bugs have been fixed for Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,16 +300,16 @@ If you need to support IE 10 as well, then you'll need to fall back to setting `
       <a href="http://codepen.io/philipwalton/pen/EVaRaX">9.2.b</a> &mdash; <em>workaround</em>
     </td>
     <td>
-      Chrome (fixed in 54)<br>
+      Chrome<br>
       Edge<br>
-      Firefox<br>
+      Firefox (fixed in 52)<br>
       Opera<br>
       Safari
     </td>
     <td>
-      <a href="https://code.google.com/p/chromium/issues/detail?id=262679">Chrome #262679 (fixed)</a><br>
+      <a href="https://code.google.com/p/chromium/issues/detail?id=375693">Chrome #375693</a><br>
       <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4511145/">Edge #4511145</a><br>
-      <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=984869">Firefox #984869</a><br>
+      <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=984869">Firefox #984869 (fixed)</a><br>
       <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1230207">Firefox #1230207 (fixed)</a><br>
       <a href="https://bugs.webkit.org/show_bug.cgi?id=148826">Safari #148826</a>
     </td>
@@ -318,7 +318,7 @@ If you need to support IE 10 as well, then you'll need to fall back to setting `
 
 Certain HTML elements, like `<fieldset>` and `<button>`, do not work as flex containers. The browsers default rendering of those element's UI conflicts with the `display: flex` declaration.
 
-Demo [9.1.a](http://codepen.io/philipwalton/pen/ByZgpW) shows how `<button>` elements don't work in Firefox, and demo [9.2.a](http://codepen.io/philipwalton/pen/wKBqdY) shows that `<fieldset>` elements don't work in most browsers.
+Demo [9.1.a](http://codepen.io/philipwalton/pen/ByZgpW) shows how `<button>` elements didn't work in Firefox, and demo [9.2.a](http://codepen.io/philipwalton/pen/wKBqdY) shows that `<fieldset>` elements don't work in most browsers.
 
 #### Workaround
 


### PR DESCRIPTION
I checked with Firefox Aurora (v52) and the demo pages. Fieldset and button elements are now fully supported.
~~As for Chrome - the fixed didn't land in v54 yet, but did one version later (/cc @cvrebert). Opera should have the fix in v42 (it's using the same engine like Chrome v55).~~ (Fix was reverted in Chrome)