### PR TITLE
Webkit #148826 and #169082 have been fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,14 +304,14 @@ If you need to support IE 10 as well, then you'll need to fall back to setting `
       Edge<br>
       Firefox<br>
       Opera<br>
-      Safari
+      Safari (fixed in 10.1)
     </td>
     <td>
       <a href="https://code.google.com/p/chromium/issues/detail?id=262679">Chrome #262679 (fixed)</a><br>
       <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4511145/">Edge #4511145</a><br>
       <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=984869">Firefox #984869</a><br>
       <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1230207">Firefox #1230207 (fixed)</a><br>
-      <a href="https://bugs.webkit.org/show_bug.cgi?id=148826">Safari #148826</a>
+      <a href="https://bugs.webkit.org/show_bug.cgi?id=169082">Safari #169082 (fixed)</a>
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ If you need to support IE 10 as well, then you'll need to fall back to setting `
       Edge<br>
       Firefox<br>
       Opera<br>
-      Safari (fixed in 10.1)
+      Safari (fixed in 11)
     </td>
     <td>
       <a href="https://code.google.com/p/chromium/issues/detail?id=262679">Chrome #262679 (fixed)</a><br>


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=148826 was marked as duplicate of https://bugs.webkit.org/show_bug.cgi?id=169082 which has been marked as fixed half an hour ago.

We probably want to wait to merge this pull request until Safari 10.1 got released.