### PR TITLE
Change IE bug tracker link to archived version

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ _`min-height` on a flex container won't apply to its flex items_
       <a href="https://codepen.io/philipwalton/pen/JdvdJE">3.2.b</a> &ndash; <em>workaround</em>
     </td>
     <td>Internet Explorer 10-11 (fixed in Edge)</td>
-    <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625</a></td>
+    <td><a href="http://web.archive.org/web/20170312223506/https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625 (archived)</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
As of January 3rd, 2018, [Microsoft Connect is no longer in service][1] and as such IE bug tracker links don't work anymore. It doesn't seem like the tracker was migrated anywhere; it was just shut down (probably because they aren't fixing anything but the most critical bugs).

Although its usefulness is limited because the bug wont be fixed, I think the bug tracking page may still be good for people to see this fact. I've updated the link to the latest archived version from the Wayback Machine.

[1]: https://docs.microsoft.com/en-us/collaborate/connect-redirect