### PR TITLE
Flexbug #1 fixed in Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,13 @@ _Minimum content sizing of flex items not honored_
       <a href="https://codepen.io/philipwalton/pen/wBopYg">1.2.b</a> &ndash; <em>workaround</em>
     </td>
     <td>
-      Chrome (partially fixed in 44)<br>
+      Chrome (fixed in 72)<br>
       Opera (partially fixed in 31)<br>
       Safari (fixed in 10)
     </td>
     <td>
       <a href="https://code.google.com/p/chromium/issues/detail?id=426898">Chrome #426898 (fixed)</a><br>
-      <a href="https://code.google.com/p/chromium/issues/detail?id=676985">Chrome #676985</a><br>
-      <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=596743">Chrome #596743</a></br>
+      <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=596743">Chrome #596743 (fixed)</a></br>
       <a href="https://bugs.webkit.org/show_bug.cgi?id=146020">Safari #146020 (fixed)</a>
     </td>
   </tr>


### PR DESCRIPTION
#596743 was fixed after a [commit on October 22][1], which was [shipped in Chrome 72.0.3589.0][2]. Chrome 72 is the current beta, [to be released at the end of January][3].

I removed #676985 because it was [merged into #596743 as a duplicate][4] back in 2017.

[1]: https://chromium.googlesource.com/chromium/src.git/+/155c1f2bf45369bc7130c89b88c75c2d3c915410
[2]: https://storage.googleapis.com/chromium-find-releases-static/155.html#155c1f2bf45369bc7130c89b88c75c2d3c915410
[3]: https://chromiumdash.appspot.com/schedule
[4]: https://bugs.chromium.org/p/chromium/issues/detail?id=676985#c8