### PR TITLE
Update fixed status of safari rendering bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ _`min-height` on a flex container won't apply to its flex items_
       <a href="https://codepen.io/philipwalton/pen/JdvdJE">3.2.b</a> &ndash; <em>workaround</em>
     </td>
     <td>Internet Explorer 10-11 (fixed in Edge)</td>
-    <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625</a></td>
+    <td><a href="http://web.archive.org/web/20170312223506/https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625 (archived)</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ _Minimum content sizing of flex items not honored_
     <td>
       Chrome (fixed in 72)<br>
       Opera (fixed in 60)<br>
-      Safari (fixed in 10)
+      Safari
     </td>
     <td>
       <a href="https://code.google.com/p/chromium/issues/detail?id=426898">Chrome #426898 (fixed)</a><br>


### PR DESCRIPTION
This bug is still active, see: https://jsfiddle.net/jdmswong/ys43uhx7/4/
```
  <div class="list">
    <div class="container">
      Flex container
    </div>
    <div>
      Non-flex container
    </div>
  </div>
```
```
.container {
  display: flex;
}

.list {
  display: flex;
  flex-direction: column;
  height: 20px;
  background-color: grey;
}
```
Chrome v84.0:
![image](https://user-images.githubusercontent.com/782984/91670624-18e74f00-ead4-11ea-9cdf-25fe0ea830f5.png)

Safari 13.1.2:
![image](https://user-images.githubusercontent.com/782984/91670630-1e449980-ead4-11ea-97e8-df0cb064aee5.png)
