### PR TITLE
Update README.md to state Chrome 86 can now render fieldset elements as flexbox containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,8 +359,8 @@ _Some HTML elements can't be flex containers_
       <a href="https://philipwalton.github.io/flexbugs/9.3.a-bug.html">9.3.a</a> &ndash; <em>bug</em><br>
     </td>
     <td>
-      Chrome<br>
-      Edge<br>
+      Chrome (fixed in 86)<br>
+      Edge Legacy<br>
       Firefox (fixed in 63)<br>
       Opera<br>
       Safari (fixed in 11)

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ _`min-height` on a flex container won't apply to its flex items_
       <a href="https://codepen.io/philipwalton/pen/JdvdJE">3.2.b</a> &ndash; <em>workaround</em>
     </td>
     <td>Internet Explorer 10-11 (fixed in Edge)</td>
-    <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625</a></td>
+    <td><a href="http://web.archive.org/web/20170312223506/https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625 (archived)</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Amended Flexbug 9 notes to state that Chrome 86 (released in October 2020) now fixes the inability to render `fieldset` elements as flexbox containers.

I've also referred to Edge as Edge Legacy within this Flexbug, as MS Edge now uses the Chromium browser.