### PR TITLE
Fix broken EdgeHTML issue tracker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ _`min-height` on a flex container won't apply to its flex items_
       <a href="https://codepen.io/philipwalton/pen/JdvdJE">3.2.b</a> &ndash; <em>workaround</em>
     </td>
     <td>Internet Explorer 10-11 (fixed in Edge)</td>
-    <td><a href="https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625</a></td>
+    <td><a href="http://web.archive.org/web/20170312223506/https://connect.microsoft.com/IE/feedback/details/802625/min-height-and-flexbox-flex-direction-column-dont-work-together-in-ie-10-11-preview">IE #802625 (archived)</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ _Column flex items ignore `margin: auto` on the cross axis_
         Internet Explorer 10-11 (fixed in Edge)
     </td>
     <td>
-        <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14593426/">IE #14593426</a>
+        <a href="https://web.archive.org/web/20171203131734/https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14593426/">IE #14593426 (archived)</a>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
This fixes a broken link by replacing it with the Wayback Machine
version. This is similar to the fix in #257 but note that the bug
trackers are different: the previous fix was for a link to an Internet
Explorer bug tracker, while this fix is for a link to an EdgeHTML bug
tracker (which apparently also accepted bug reports for IE). Presumably
Microsoft discontinued this bug tracker when Edge switched to Chromium
for its browser engine.